### PR TITLE
MD5 deprecated, Sha256 hash check

### DIFF
--- a/shopify.php
+++ b/shopify.php
@@ -12,19 +12,16 @@
 
 	function is_valid_request($query_params, $shared_secret)
 	{
-		if (!isset($query_params['timestamp'])) return false;
-
-		$seconds_in_a_day = 24 * 60 * 60;
-		$older_than_a_day = $query_params['timestamp'] < (time() - $seconds_in_a_day);
-		if ($older_than_a_day) return false;
-
-		$signature = $query_params['signature'];
-		unset($query_params['signature']);
-
-		foreach ($query_params as $key=>$val) $params[] = "$key=$val";
-		sort($params);
-
-		return (md5($shared_secret.implode('', $params)) === $signature);
+		if(!is_array($query_params))
+			return false;
+		if(array_key_exists('shop',$query_params) && array_key_exists('timestamp',$query_params) && array_key_exists('hmac',$query_params)) {
+			$hmac = $query_params['hmac'];
+			unset($query_params['signature']);
+			unset($query_params['hmac']);
+			ksort($query_params);
+			return $hmac == hash_hmac('sha256', http_build_query($query_params), $shared_secret);
+		}
+		return false;
 	}
 
 

--- a/shopify.php
+++ b/shopify.php
@@ -19,7 +19,19 @@
 			unset($query_params['signature']);
 			unset($query_params['hmac']);
 			ksort($query_params);
-			return $hmac == hash_hmac('sha256', http_build_query($query_params), $shared_secret);
+
+			foreach($query_params as $param => $value) {
+				$param = str_replace('%', '%25', $param);
+				$param = str_replace('&', '%26', $param);
+				$param = str_replace('=', '%3D', $param);
+
+				$value = str_replace('%', '%25', $value);
+				$value = str_replace('&', '%26', $value);
+
+				$params[$param] = "{$param}={$value}";
+			}
+
+			return $hmac == hash_hmac('sha256', implode('&', $params), $shared_secret);
 		}
 		return false;
 	}


### PR DESCRIPTION
Since the HMAC-check isn't being done via md5 anymore, here's some new logic. 
I've followed the rules from the documentation. $query_params would be equal to the full $_GET-object.
