### PR TITLE
Set json_decode() JSON_BIGINT_AS_STRING flag to avoid int32 wrapping/…

### DIFF
--- a/shopify.php
+++ b/shopify.php
@@ -118,7 +118,7 @@
 		function __construct($message, $code, $request, $response=array(), Exception $previous=null)
 		{
 			$response_body_json = isset($response['body']) ? $response['body'] : '';
-			$response = json_decode($response_body_json, true);
+			$response = json_decode($response_body_json, true, 512, JSON_BIGINT_AS_STRING);
 			$response_error = isset($response['errors']) ? ' '.var_export($response['errors'], true) : '';
 			$this->message = $message.$response_error;
 			parent::__construct($this->message, $code, $request, $response, $previous);


### PR DESCRIPTION
…saturation on large resource identifiers